### PR TITLE
docs: refresh org README as SDK directory; update partners page

### DIFF
--- a/partners.md
+++ b/partners.md
@@ -3,21 +3,19 @@ Partners
 
 Clarius is excited to be working with multiple partners that are bringing new technologies into the healthcare space that require ultrasound imaging for real-time guidance and other novel clinical solutions.
 
-Working with Clarius scanners is extremely simple, and leveraging our suite of APIs through our **Clarius SDK** program allows partners to build elegant solutions that work directly with Clarius' existing ecosystem, or to build an entirely standalone solution.
+Working with Clarius scanners is extremely simple, and leveraging our suite of APIs through our **Clarius SDK** program allows partners to build elegant solutions that work directly with Clarius' existing ecosystem, or to build an entirely standalone solution. See the [Clarius SDK home](https://github.com/clariusdev/.github/blob/main/profile/README.md) for all available repositories.
 
 OEM Partnerships
 ================
 
-Those wishing to develop completely standalone solutions can work with Clarius and enter into an OEM partnership that will allow a 3rd party to purchase and deploy Clarius scanners on their own technology platform to their own customers. Some eligibility requirements for becoming an OEM partner include:
-* Minimum yearly purchase of scanners
-* Paying a nominal yearly fee per scanner (the oem license)
-* Paying a yearly support fee for training, support, and any custom development required
+Those wishing to develop completely standalone solutions can work with Clarius and enter into an OEM partnership that will allow a 3rd party to purchase and deploy Clarius scanners on their own technology platform to their own customers. Enabling the OEM program for your customers requires a general partnership agreement with Clarius; [contact us](https://clarius.com/) to discuss the details for your solution.
 
 From the technology standpoint, partners can develop and deploy in any means they wish, however we have built the dedicated [Solum API](https://github.com/clariusdev/solum) for creating standalone software and Apps. Developers are encouraged to build a full ecosystems for their customers with potential to use cloud, implement custom analysis and reporting, and build in proper security measures.
 
 Solum is available for deployment on the following platforms:
  * Windows
  * Linux
+ * macOS
  * iOS
  * Android
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,15 +1,42 @@
 # Clarius SDK
 
-Welcome to the Clarius SDK home; here you'll find various repositories for both [partners](https://github.com/clariusdev/.github/blob/main/partners.md) and researchers making use of Clarius technology for commercial solutions, signal processing, AI research, and more.
+Welcome to the Clarius SDK — the home for the APIs, tools, and references used by
+[partners](https://github.com/clariusdev/.github/blob/main/partners.md) and researchers
+building on Clarius wireless ultrasound: commercial OEM solutions, real-time streaming,
+signal processing, AI research, and more.
 
-What's New
-==========
+## Repositories
 
-Version 11.2.0 is now released with updated APIs and binaries available.
+| Repository | What it's for |
+| ---------- | ------------- |
+| **[Solum](https://github.com/clariusdev/solum)** | OEM API for building standalone applications that connect **directly** to a Clarius scanner — no Clarius App required. Connectivity and imaging control on Windows, Linux, macOS, iOS, and Android. For commercial partners. |
+| **[Cast](https://github.com/clariusdev/cast)** | Stream images and data in **real time** from a probe while the Clarius App is running. The simplest way to get live images and raw data for research. |
+| **[Research](https://github.com/clariusdev/research)** | Raw data formats (RF / IQ / envelope) and readers, the in-app research tools, how imaging parameters are automated, and the low-level parameter reference. |
+| **[IMU](https://github.com/clariusdev/imu)** | The integrated 9-DOF inertial measurement unit: data access, calibration, and orientation quaternions. |
+| **[Cloud](https://github.com/clariusdev/cloud)** | Framework for pushing completed exams from Clarius Cloud into other platforms — clinical review, cloud AI and reporting, and EMR integrations. |
 
-* [Cast API](https://github.com/clariusdev/cast) Linux ARM64 Build Included
-* [Cast API](https://github.com/clariusdev/cast) Method to Query Raw Data Timestamps
+> **Texo** — script-driven research imaging for low-level control of the transmit/receive
+> sequence — is coming soon.
 
-* [Solum API](https://github.com/clariusdev/solum) Linux ARM64 Build Included
-* [Solum API](https://github.com/clariusdev/solum) Method to Query Raw Data Timestamps
-* [Solum API](https://github.com/clariusdev/solum) New Setting for Forcing Stream of Probe Logs While Imaging
+## Which one do I need?
+
+- **Build a standalone product that controls the probe directly** → **Solum** (requires an
+  OEM partnership).
+- **Get real-time images or data alongside the Clarius App** → **Cast**.
+- **Analyze raw RF/IQ/envelope data or use the in-app research features** → **Research**
+  (plus **IMU** for motion/orientation).
+- **Integrate completed exams with your cloud, EMR, or AI service** → **Cloud**.
+
+## Releases
+
+The APIs are matched to the Clarius App: new binaries and source are published alongside
+each App release, and there is no forward/backward compatibility across versions. Always
+use the build that matches your App — see each repository's **Releases** page for the
+latest.
+
+## Partners
+
+Clarius works with partners bringing new technologies into healthcare that need ultrasound
+for real-time guidance and other clinical solutions. See the
+[partners page](https://github.com/clariusdev/.github/blob/main/partners.md) for OEM
+partnerships, cloud integrations, and how to get started.


### PR DESCRIPTION
- profile/README.md: replaces the stale 'What's New in 11.2' section with a directory of the documented repos (solum, cast, research, imu, cloud), a 'which one do I need?' guide, and a version-agnostic releases note.
- partners.md: adds macOS to Solum platforms, links the SDK home, and genericizes the OEM terms (removes MOQ/fees) in favor of a partnership-agreement + contact-us flow.